### PR TITLE
Add message_posted event trigger example

### DIFF
--- a/Event_Triggers/triggers/messages_posted.ts
+++ b/Event_Triggers/triggers/messages_posted.ts
@@ -1,0 +1,35 @@
+import { Trigger } from "deno-slack-sdk/types.ts";
+import {
+  TriggerContextData,
+  TriggerEventTypes,
+  TriggerTypes,
+} from "deno-slack-api/mod.ts";
+import workflow from "../workflows/ping_pong_message.ts";
+
+const trigger: Trigger<typeof workflow.definition> = {
+  type: TriggerTypes.Event,
+  name: "Trigger the ping-pong message workflow",
+  workflow: `#/workflows/${workflow.definition.callback_id}`,
+  event: {
+    event_type: TriggerEventTypes.MessagePosted,
+    // TODO: Update this list
+    channel_ids: ["C03E94MKS"],
+    // See https://api.slack.com/automation/triggers/event for details
+    filter: {
+      version: 1,
+      root: {
+        operator: "OR",
+        inputs: [
+          { statement: "{{data.text}} CONTAINS 'PING'" },
+          { statement: "{{data.text}} CONTAINS 'Ping'" },
+          { statement: "{{data.text}} CONTAINS 'ping'" },
+        ],
+      },
+    },
+  },
+  inputs: {
+    channel_id: { value: TriggerContextData.Event.MessagePosted.channel_id },
+    message_ts: { value: TriggerContextData.Event.MessagePosted.message_ts },
+  },
+};
+export default trigger;

--- a/Event_Triggers/workflows/ping_pong_message.ts
+++ b/Event_Triggers/workflows/ping_pong_message.ts
@@ -1,0 +1,24 @@
+import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+
+const workflow = DefineWorkflow({
+  callback_id: "ping-pong-message-workflow",
+  title: "Ping Pong Message Workflow",
+  input_parameters: {
+    properties: {
+      // All the possible inputs from the "message_posted" event trigger
+      channel_id: { type: Schema.slack.types.channel_id },
+      message_ts: { type: Schema.types.string },
+    },
+    required: ["channel_id", "message_ts"],
+  },
+});
+
+workflow.addStep(Schema.slack.functions.ReplyInThread, {
+  message_context: {
+    channel_id: workflow.inputs.channel_id,
+    message_ts: workflow.inputs.message_ts,
+  },
+  message: ":wave: Pong!",
+});
+
+export default workflow;

--- a/manifest.ts
+++ b/manifest.ts
@@ -21,6 +21,7 @@ import Tasks from "./Datastores/datastores/tasks.ts";
 // Event_Triggers/*
 import MessageToChannelCreatorWorkflow from "./Event_Triggers/workflows/message_to_channel_creator.ts";
 import ReplyToReactionWorkflow from "./Event_Triggers/workflows/reply_to_reaction.ts";
+import PingPongMessageWorkflow from "./Event_Triggers/workflows/ping_pong_message.ts";
 
 // Scheduled Triggers/*
 import ScheduledWorkflow from "./Scheduled_Triggers/workflows/do_nothing.ts";
@@ -51,6 +52,7 @@ export default Manifest({
     TaskManagerWorkflow,
     MessageToChannelCreatorWorkflow,
     ReplyToReactionWorkflow,
+    PingPongMessageWorkflow,
     ScheduledWorkflow,
     InteractiveBlocksModalDemoWorkflow,
     BlockKitButtonDemoWorkflow,
@@ -68,6 +70,7 @@ export default Manifest({
     "chat:write.public",
     "channels:read", // for Event_Triggers's MessageToChannelCreatorWorkflow
     "reactions:read", // for Event_Triggers's ReplyToReactionWorkflow
+    "channels:history", // for Event_Triggers's PingPongMessageWorkflow
     "datastore:read", // for Datastores/*
     "datastore:write", // for Datastores/*
   ],


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This pull request adds a new simple example code demonstrating how to use message_posted event trigger with a set of filter rules.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
