### PR TITLE
Block Kit Modals snippet: ensure we complete the function

### DIFF
--- a/Block_Kit_Modals/functions/demo.ts
+++ b/Block_Kit_Modals/functions/demo.ts
@@ -144,8 +144,11 @@ export default SlackFunction(
   // ---------------------------
   .addViewClosedHandler(
     ["first-page", "second-page", "completion"],
-    ({ view }) => {
+    async ({ body, client, view }) => {
       console.log(`view_closed handler called: ${JSON.stringify(view)}`);
-      return { completed: true };
+      await client.functions.completeSuccess({
+        function_execution_id: body.function_data.execution_id,
+        outputs: {}
+      });
     },
   );

--- a/Block_Kit_Modals/functions/demo.ts
+++ b/Block_Kit_Modals/functions/demo.ts
@@ -148,7 +148,7 @@ export default SlackFunction(
       console.log(`view_closed handler called: ${JSON.stringify(view)}`);
       await client.functions.completeSuccess({
         function_execution_id: body.function_data.execution_id,
-        outputs: {}
+        outputs: {},
       });
     },
   );


### PR DESCRIPTION
With the block kit modal example as-is, while it works and no errors are shown, we do not complete the function, and thus the workflow. The in-line `response_action`-based approach to interactivity handler return values do not allow us to control anything about function or workflow state in the automation platform.

This PR calls `functions.completeSuccess` to ensure we 'close' the function/workflow state appropriately.

`slack run` logs prior to this PR, after running through the flow this snippet shows off:

```
Connected, awaiting events
2024-01-08 11:46:33 [info] [Wf06CU3ELAN9] (Trace=Tr06CZEUSK6G) Shortcut trigger successfully started execution of function 'Block Kit Modal Demo Workflow'
2024-01-08 11:46:33 [info] [Fn06CWTHH0QK] (Trace=Tr06CZEUSK6G) Function 'Block Kit Modal Demo Workflow' (workflow function) started
2024-01-08 11:46:33 [info] [Wf06CU3ELAN9] (Trace=Tr06CZEUSK6G) Workflow 'Block Kit Modal Demo Workflow' started
2024-01-08 11:46:34 [info] [Wf06CU3ELAN9] (Trace=Tr06CZEUSK6G) Workflow step 1 of 1 started
2024-01-08 11:46:34 [info] [Fn06CWTHGH0T] (Trace=Tr06CZEUSK6G) Function 'Block Kit modal demo' (app function) started
view_closed handler called: {"id":"V06CGEZLF8X","team_id":"T029V6468RL","app_id":"A06CZEP1KMJ","app_installed_team_id":"T029V6468RL","bot_id":"B06CGETMEQP","title":{"type":"plain_text","text":"My App","emoji":true},"type":"modal","blocks":[{"type":"section","block_id":"Uuao9","text":{"type":"mrkdwn","text":"First: first test first test first test","verbatim":false}},{"type":"section","block_id":"RtDGp","text":{"type":"mrkdwn","text":"Second: second","verbatim":false}}],"close":{"type":"plain_text","text":"Close","emoji":true},"submit":null,"state":{"values":{}},"hash":"1704732411.IE43FEwR","private_metadata":"","callback_id":"completion","root_view_id":"V06CGEZLF8X","previous_view_id":null,"clear_on_close":false,"notify_on_close":true,"external_id":""}
```

Note there is no logging to say that function completed and the workflow is done.

`slack run` logs from this PR:

```
Connected, awaiting events
2024-01-08 11:48:46 [info] [Wf06CU3ELAN9] (Trace=Tr06CWU3MH0B) Shortcut trigger successfully started execution of function 'Block Kit Modal Demo Workflow'
2024-01-08 11:48:46 [info] [Fn06CWTHH0QK] (Trace=Tr06CWU3MH0B) Function 'Block Kit Modal Demo Workflow' (workflow function) started
2024-01-08 11:48:47 [info] [Wf06CU3ELAN9] (Trace=Tr06CWU3MH0B) Workflow 'Block Kit Modal Demo Workflow' started
2024-01-08 11:48:47 [info] [Wf06CU3ELAN9] (Trace=Tr06CWU3MH0B) Workflow step 1 of 1 started
2024-01-08 11:48:47 [info] [Fn06CWTHGH0T] (Trace=Tr06CWU3MH0B) Function 'Block Kit modal demo' (app function) started
view_closed handler called: {"id":"V06CQCLGVSS","team_id":"T029V6468RL","app_id":"A06CZEP1KMJ","app_installed_team_id":"T029V6468RL","bot_id":"B06CGETMEQP","title":{"type":"plain_text","text":"My App","emoji":true},"type":"modal","blocks":[{"type":"section","block_id":"mwrvW","text":{"type":"mrkdwn","text":"First: asdfasdfadsfadsfdasfasfasdfsdaf","verbatim":false}},{"type":"section","block_id":"Q6hZa","text":{"type":"mrkdwn","text":"Second: asdfasdfasdf","verbatim":false}}],"close":{"type":"plain_text","text":"Close","emoji":true},"submit":null,"state":{"values":{}},"hash":"1704732534.fE5uvhij","private_metadata":"","callback_id":"completion","root_view_id":"V06CQCLGVSS","previous_view_id":null,"clear_on_close":false,"notify_on_close":true,"external_id":""}
2024-01-08 11:48:56 [info] [Fn06CWTHGH0T] (Trace=Tr06CWU3MH0B) Function 'Block Kit modal demo' (app function) completed
2024-01-08 11:48:56 [info] [Wf06CU3ELAN9] (Trace=Tr06CWU3MH0B) Workflow step 'Block Kit modal demo' completed
2024-01-08 11:48:56 [info] [Fn06CWTHH0QK] (Trace=Tr06CWU3MH0B) Function 'Block Kit Modal Demo Workflow' (workflow function) completed
2024-01-08 11:48:56 [info] [Wf06CU3ELAN9] (Trace=Tr06CWU3MH0B) Workflow 'Block Kit Modal Demo Workflow' completed
```

Now we close the function/workflow appropriately.