### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/Block_Kit_Modals/functions/demo.ts
+++ b/Block_Kit_Modals/functions/demo.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 export const def = DefineFunction({
   callback_id: "block-kit-modal-demo",

--- a/Block_Kit_Modals/triggers/link.ts
+++ b/Block_Kit_Modals/triggers/link.ts
@@ -1,4 +1,4 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
+import { Trigger } from "@slack/sdk/types.ts";
 import workflow from "../workflows/block_kit_modal_demo.ts";
 
 /**

--- a/Block_Kit_Modals/workflows/block_kit_modal_demo.ts
+++ b/Block_Kit_Modals/workflows/block_kit_modal_demo.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as Demo } from "../functions/demo.ts";
 
 const workflow = DefineWorkflow({

--- a/Built-in_Forms/triggers/link.ts
+++ b/Built-in_Forms/triggers/link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/form_demo.ts";
 
 /**

--- a/Built-in_Forms/workflows/form_demo.ts
+++ b/Built-in_Forms/workflows/form_demo.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 const workflow = DefineWorkflow({
   callback_id: "form-demo-workflow",

--- a/Button_Interactions/functions/handle_interactive_blocks.ts
+++ b/Button_Interactions/functions/handle_interactive_blocks.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 export const def = DefineFunction({
   callback_id: "handle-interactive-blocks",

--- a/Button_Interactions/functions/send_block_kit_message.ts
+++ b/Button_Interactions/functions/send_block_kit_message.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 export const def = DefineFunction({
   callback_id: "send_interactive_message",

--- a/Button_Interactions/triggers/block_kit_button_link.ts
+++ b/Button_Interactions/triggers/block_kit_button_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/block_kit_button_demo.ts";
 
 /**

--- a/Button_Interactions/triggers/interactive_blocks_link.ts
+++ b/Button_Interactions/triggers/interactive_blocks_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/interactive_blocks_demo.ts";
 
 /**

--- a/Button_Interactions/workflows/block_kit_button_demo.ts
+++ b/Button_Interactions/workflows/block_kit_button_demo.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as SendBlockKitMessage } from "../functions/send_block_kit_message.ts";
 
 const workflow = DefineWorkflow({

--- a/Button_Interactions/workflows/interactive_blocks_demo.ts
+++ b/Button_Interactions/workflows/interactive_blocks_demo.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as HandleInteractiveBlocks } from "../functions/handle_interactive_blocks.ts";
 
 const workflow = DefineWorkflow({

--- a/Canvases/triggers/canvas_copy_link.ts
+++ b/Canvases/triggers/canvas_copy_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/copy_canvas.ts";
 
 /**

--- a/Canvases/triggers/canvas_create_link.ts
+++ b/Canvases/triggers/canvas_create_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/create_canvas.ts";
 
 /**

--- a/Canvases/triggers/canvas_share_link.ts
+++ b/Canvases/triggers/canvas_share_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/share_canvas.ts";
 
 /**

--- a/Canvases/triggers/canvas_update_link.ts
+++ b/Canvases/triggers/canvas_update_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/update_canvas.ts";
 
 /**

--- a/Canvases/workflows/copy_canvas.ts
+++ b/Canvases/workflows/copy_canvas.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to create a canvas and copy it.

--- a/Canvases/workflows/create_canvas.ts
+++ b/Canvases/workflows/create_canvas.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to create a canvas.

--- a/Canvases/workflows/share_canvas.ts
+++ b/Canvases/workflows/share_canvas.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to create a canvas with content and share it with channels and user.

--- a/Canvases/workflows/update_canvas.ts
+++ b/Canvases/workflows/update_canvas.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how a canvas.

--- a/Connectors/triggers/giphy.ts
+++ b/Connectors/triggers/giphy.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/giphy.ts";
 
 const trigger: Trigger<typeof workflow.definition> = {

--- a/Connectors/triggers/google_calendar.ts
+++ b/Connectors/triggers/google_calendar.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/google_calendar.ts";
 
 const trigger: Trigger<typeof workflow.definition> = {

--- a/Connectors/workflows/giphy.ts
+++ b/Connectors/workflows/giphy.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { Connectors } from "deno-slack-hub/mod.ts";
 
 const workflow = DefineWorkflow({

--- a/Connectors/workflows/google_calendar.ts
+++ b/Connectors/workflows/google_calendar.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { Connectors } from "deno-slack-hub/mod.ts";
 
 const workflow = DefineWorkflow({

--- a/Custom_Functions/functions/my_send_message.ts
+++ b/Custom_Functions/functions/my_send_message.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 export const def = DefineFunction({
   callback_id: "my_send_message",

--- a/Custom_Functions/functions/my_send_message_test.ts
+++ b/Custom_Functions/functions/my_send_message_test.ts
@@ -1,5 +1,5 @@
 import {stub} from "@std/testing/mock";
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import handler from "./my_send_message.ts";
 

--- a/Custom_Functions/triggers/link.ts
+++ b/Custom_Functions/triggers/link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/my_send_message_workflow.ts";
 
 /**

--- a/Custom_Functions/workflows/my_send_message_workflow.ts
+++ b/Custom_Functions/workflows/my_send_message_workflow.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as MySendMessage } from "../functions/my_send_message.ts";
 
 const workflow = DefineWorkflow({

--- a/Datastores/datastores/pto.ts
+++ b/Datastores/datastores/pto.ts
@@ -1,4 +1,4 @@
-import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineDatastore, Schema } from "@slack/sdk";
 
 // Refer to https://api.slack.com/automation/datastores for details
 const datastore = DefineDatastore({

--- a/Datastores/datastores/tasks.ts
+++ b/Datastores/datastores/tasks.ts
@@ -1,4 +1,4 @@
-import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineDatastore, Schema } from "@slack/sdk";
 
 // Refer to https://api.slack.com/automation/datastores for details
 const datastore = DefineDatastore({

--- a/Datastores/functions/pto_demo.ts
+++ b/Datastores/functions/pto_demo.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 import PTO from "../datastores/pto.ts";
 
 export const def = DefineFunction({

--- a/Datastores/functions/tasks_demo.ts
+++ b/Datastores/functions/tasks_demo.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, SlackFunction } from "@slack/sdk";
 import Tasks from "../datastores/tasks.ts";
 
 export const def = DefineFunction({

--- a/Datastores/triggers/pto_link.ts
+++ b/Datastores/triggers/pto_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerTypes } from "@slack/api";
 import workflow from "../workflows/pto.ts";
 
 /**

--- a/Datastores/triggers/task_link.ts
+++ b/Datastores/triggers/task_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerTypes } from "@slack/api";
 import workflow from "../workflows/task_manager.ts";
 
 /**

--- a/Datastores/workflows/pto.ts
+++ b/Datastores/workflows/pto.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as PTODemo } from "../functions/pto_demo.ts";
 
 const workflow = DefineWorkflow({

--- a/Datastores/workflows/task_manager.ts
+++ b/Datastores/workflows/task_manager.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow } from "@slack/sdk";
 import { def as TasksDemo } from "../functions/tasks_demo.ts";
 
 const workflow = DefineWorkflow({

--- a/Event_Triggers/triggers/channel_created.ts
+++ b/Event_Triggers/triggers/channel_created.ts
@@ -1,9 +1,9 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
+import { Trigger } from "@slack/sdk/types.ts";
 import {
   TriggerContextData,
   TriggerEventTypes,
   TriggerTypes,
-} from "deno-slack-api/mod.ts";
+} from "@slack/api";
 import workflow from "../workflows/message_to_channel_creator.ts";
 
 const trigger: Trigger<typeof workflow.definition> = {

--- a/Event_Triggers/triggers/messages_posted.ts
+++ b/Event_Triggers/triggers/messages_posted.ts
@@ -1,9 +1,9 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
+import { Trigger } from "@slack/sdk/types.ts";
 import {
   TriggerContextData,
   TriggerEventTypes,
   TriggerTypes,
-} from "deno-slack-api/mod.ts";
+} from "@slack/api";
 import workflow from "../workflows/ping_pong_message.ts";
 
 const trigger: Trigger<typeof workflow.definition> = {

--- a/Event_Triggers/triggers/reaction_added.ts
+++ b/Event_Triggers/triggers/reaction_added.ts
@@ -1,9 +1,9 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
+import { Trigger } from "@slack/sdk/types.ts";
 import {
   TriggerContextData,
   TriggerEventTypes,
   TriggerTypes,
-} from "deno-slack-api/mod.ts";
+} from "@slack/api";
 import workflow from "../workflows/reply_to_reaction.ts";
 
 const trigger: Trigger<typeof workflow.definition> = {

--- a/Event_Triggers/workflows/message_to_channel_creator.ts
+++ b/Event_Triggers/workflows/message_to_channel_creator.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 const workflow = DefineWorkflow({
   callback_id: "message-to-channel-creator-workflow",

--- a/Event_Triggers/workflows/ping_pong_message.ts
+++ b/Event_Triggers/workflows/ping_pong_message.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 const workflow = DefineWorkflow({
   callback_id: "ping-pong-message-workflow",

--- a/Event_Triggers/workflows/reply_to_reaction.ts
+++ b/Event_Triggers/workflows/reply_to_reaction.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 const workflow = DefineWorkflow({
   callback_id: "reply-to-reaction-workflow",

--- a/External_API_Calls/functions/httpbin_get.ts
+++ b/External_API_Calls/functions/httpbin_get.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 export const def = DefineFunction({
   callback_id: "httpbin_get",

--- a/External_API_Calls/functions/httpbin_get_test.ts
+++ b/External_API_Calls/functions/httpbin_get_test.ts
@@ -1,6 +1,6 @@
 import {stub} from "@std/testing/mock";
 import { assertEquals } from "@std/assert";
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import handler from "./httpbin_get.ts";
 
 const { createContext } = SlackFunctionTester("my-function");

--- a/External_API_Calls/triggers/link.ts
+++ b/External_API_Calls/triggers/link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/ephemeral_message.ts";
 
 /**

--- a/External_API_Calls/workflows/ephemeral_message.ts
+++ b/External_API_Calls/workflows/ephemeral_message.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as HttpbinGet } from "../functions/httpbin_get.ts";
 
 /**

--- a/Messaging/triggers/channel_message_link.ts
+++ b/Messaging/triggers/channel_message_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/channel_message.ts";
 
 /**

--- a/Messaging/triggers/channel_message_webhook.ts
+++ b/Messaging/triggers/channel_message_webhook.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerTypes } from "@slack/api";
 import workflow from "../workflows/channel_message.ts";
 
 /**

--- a/Messaging/triggers/direct_message_link.ts
+++ b/Messaging/triggers/direct_message_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/direct_message.ts";
 
 /**

--- a/Messaging/triggers/ephemeral_message_link.ts
+++ b/Messaging/triggers/ephemeral_message_link.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import workflow from "../workflows/ephemeral_message.ts";
 
 /**

--- a/Messaging/workflows/channel_message.ts
+++ b/Messaging/workflows/channel_message.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to post a message in a channel.

--- a/Messaging/workflows/direct_message.ts
+++ b/Messaging/workflows/direct_message.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to send a DM.

--- a/Messaging/workflows/ephemeral_message.ts
+++ b/Messaging/workflows/ephemeral_message.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 
 /**
  * This workflow demonstrates how to post an ephemeral message in a channel.

--- a/Scheduled_Triggers/triggers/scheduled_only_once.ts
+++ b/Scheduled_Triggers/triggers/scheduled_only_once.ts
@@ -1,5 +1,5 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerTypes } from "deno-slack-api/mod.ts";
+import { Trigger } from "@slack/sdk/types.ts";
+import { TriggerTypes } from "@slack/api";
 import workflow from "../workflows/do_nothing.ts";
 
 /**

--- a/Scheduled_Triggers/workflows/do_nothing.ts
+++ b/Scheduled_Triggers/workflows/do_nothing.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow } from "@slack/sdk";
 
 /**
  * This workflow does nothing, but you can confirm it was invoked by checking `slack activity -t` command outputs.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -32,7 +32,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
 
     "deno-slack-hub/": "https://deno.land/x/deno_slack_hub@3.3.0/",
     "@std/assert": "jsr:@std/assert@^1.0.15",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,8 +31,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+
     "deno-slack-hub/": "https://deno.land/x/deno_slack_hub@3.3.0/",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/testing": "jsr:@std/testing@^1.0.16"

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 
 // Messaging/*
 import ChannelMessageWorkflow from "./Messaging/workflows/channel_message.ts";


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)